### PR TITLE
Updated to import PropTypes from the 'prop-types' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "object-assign": "^3.0.0",
+    "prop-types": "^15.5.8",
     "react": "^0.14.7 || ^15.0.0",
     "react-dom": "^0.14.7 || ^15.0.0"
   }

--- a/src/notify.js
+++ b/src/notify.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import assign from 'object-assign';
 


### PR DESCRIPTION
As per the deprecation warning and note on the [docs](https://facebook.github.io/react/docs/typechecking-with-proptypes.html) I have updated this package to remove warnings. I don't know much about your versioning so I left that alone.

Let me know if you see any issues with this.