### PR TITLE
Support for multiline content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- [\#26] Support for multiline texts
 
 ### Changed
 
 ### Fixed
+- [\#44] Fixed animation positioning for content that's more than 3 lines of height
 
 ## [0.3.2] - 2017-08-23
 - [\#42] Show queue was not working due to references to non existing variables

--- a/src/stylesheet.js
+++ b/src/stylesheet.js
@@ -12,7 +12,7 @@ class Stylesheet {
                 width: '50%',
                 margin: '0 auto',
                 right: '0px',
-                top: '-100px',
+                bottom: '100%',
                 left: '0px',
                 textAlign: 'center',
                 zIndex: defaults.zIndex,
@@ -32,7 +32,7 @@ class Stylesheet {
             },
             content: {
                 cursor: 'pointer',
-                display: 'inline',
+                display: 'inline-block',
                 width: 'auto',
                 borderRadius: '0 0 4px 4px',
                 backgroundColor: 'white',
@@ -40,18 +40,18 @@ class Stylesheet {
                 pointerEvents: 'all'
             },
             show: {
-                transform: 'translateY(108px)',
-                msTransform: 'translateY(108px)',
-                WebkitTransform: 'translateY(108px)',
-                OTransform: 'translateY(108px)',
-                MozTransform: 'translateY(108px)'
+                transform: 'translateY(100%)',
+                msTransform: 'translateY(100%)',
+                WebkitTransform: 'translateY(100%)',
+                OTransform: 'translateY(100%)',
+                MozTransform: 'translateY(100%)'
             },
             hide: {
-                transform: 'translateY(-108px)',
-                msTransform: 'translateY(-108px)',
-                WebkitTransform: 'translateY(-108px)',
-                OTransform: 'translateY(-108px)',
-                MozTransform: 'translateY(-108px)'
+                transform: 'translateY(-100%)',
+                msTransform: 'translateY(-100%)',
+                WebkitTransform: 'translateY(-100%)',
+                OTransform: 'translateY(-100%)',
+                MozTransform: 'translateY(-100%)'
             }
         };
     }


### PR DESCRIPTION
This PR adds support for multiline content using feedback from issues #26 and #44 

I need help to test that this covers current use cases. I have tested some notifications across one of my applications and the change seems to be fully backwards compatible, but I want to make sure that I'm not breaking anyone's app with this update.

If you would like to contribute, please follow these steps to try the latest version in your application:
```sh
git clone git@github.com:jesusoterogomez/react-notify-toast.git
cd react-notify-toast
npm link && npm run compile

# in your application
npm link react-notify-toast

# Run your app as normal and test that notifications work as expected
```

To test a multiline notification
```js
// JSX content
notify.show(<span>This is a <br/>multiline</br>notification</span>);

// String
notify.show("use an insanely long string here");
```